### PR TITLE
Add and Raise PolyBoolException

### DIFF
--- a/polybool/__init__.py
+++ b/polybool/__init__.py
@@ -7,6 +7,10 @@ T = typing.TypeVar("T")
 TPoint = typing.TypeVar("TPoint", bound="Point")
 
 
+class PolyBoolException(Exception):
+    pass
+
+
 class Point:
     def __init__(self: TPoint, x: float, y: float) -> None:
         self.x = x
@@ -539,7 +543,7 @@ class Intersecter:
             else:
                 st = ev.status
                 if st is None:
-                    raise Exception(
+                    raise PolyBoolException(
                         "PolyBool: Zero-length segment detected; your epsilon is probably too small or too large"
                     )
                 if statusRoot.exists(st.previous) and statusRoot.exists(st.next):


### PR DESCRIPTION
Correct too broad exception KaivnD/pypolybool#4

Catching a raw `Exception` will always say that that is too broad. However the polybool error in question is very specific.